### PR TITLE
Add a "buckProjects" configuration to the OkBuckExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ okbuck {
                     'armeabi',
             ]
     ]
+    buckProjects = project.subprojects
 }
 ```
 
@@ -154,6 +155,8 @@ you need, default is empty, which will generate all flavors BUCK file
 +  `cpuFilters` is a map, used for controlling BUCK only create the specific cpu architecture
 native library folder in your apk file, the same as `ndk.abiFilter` of gradle, support values
 are: `armeabi`, `armeabi-v7a`, `x86`, `x86_64`, `mips`
++  `buckProjects` is a set of projects to generate buck configs for.
+Default is all sub projects of root project.
 
 ## Troubleshooting
 If you come with bugs of OkBuck, please [open an issue](https://github.com/Piasy/OkBuck/issues/new), 
@@ -183,9 +186,6 @@ and [ref2](http://stackoverflow.com/a/18144853/3077508)
 ## Contribution
 Any form of contributions are welcome! See the [detail todo list](https://github.com/Piasy/
 OkBuck/wiki/TODO-list).
-
-Note that you need create an empty file named `bintray.properties` in `/buildSrc/`, which is 
-used for publishing to bintray.
 
 ## Acknowledgement
 +  Thanks for Facebook open source [buck](https://github.com/facebook/buck) build system.

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ okbuck {
                     'prod',
             ]
     ]
+    buckProjects = project.subprojects.findAll { it.name != "plugin" }
 }
 
 task clean(type: Delete) {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -84,7 +84,9 @@ version = publishVersion
 Properties properties = new Properties()
 // for wrapper project structure
 File propertyFile = project.rootProject.file('bintray.properties')
-properties.load(propertyFile.newDataInputStream())
+if (propertyFile.exists()) {
+    properties.load(propertyFile.newDataInputStream())
+}
 
 publishing {
     publications {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 def siteUrl = 'https://github.com/Piasy/OkBuck'
 def gitUrl = 'https://github.com/Piasy/OkBuck.git'
 def publishGroup = 'com.github.piasy'
-def publishVersion = '1.0.0-beta9'
+def publishVersion = '1.0.0-beta8'
 
 group = publishGroup
 version = publishVersion

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 def siteUrl = 'https://github.com/Piasy/OkBuck'
 def gitUrl = 'https://github.com/Piasy/OkBuck.git'
 def publishGroup = 'com.github.piasy'
-def publishVersion = '1.0.0-beta8'
+def publishVersion = '1.0.0-beta9'
 
 group = publishGroup
 version = publishVersion

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/OkBuckExtension.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/OkBuckExtension.groovy
@@ -91,9 +91,12 @@ public class OkBuckExtension {
      * */
     Map<String, List<String>> cpuFilters = new HashMap<>()
 
-    Collection<Project> toBuck
+    /**
+     * Set of projects to generate buck configs for. Default is all subprojects of root project.
+     */
+    Set<Project> buckProjects
 
     OkBuckExtension(Project project) {
-        toBuck = project.subprojects
+        buckProjects = project.subprojects
     }
 }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/OkBuckExtension.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/OkBuckExtension.groovy
@@ -23,6 +23,8 @@
  */
 package com.github.piasy.okbuck
 
+import org.gradle.api.Project
+
 /**
  * okbuck dsl.
  * */
@@ -88,4 +90,10 @@ public class OkBuckExtension {
      * cpu filters
      * */
     Map<String, List<String>> cpuFilters = new HashMap<>()
+
+    Collection<Project> toBuck
+
+    OkBuckExtension(Project project) {
+        toBuck = project.subprojects
+    }
 }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/OkBuckGradlePlugin.groovy
@@ -42,7 +42,7 @@ import org.gradle.api.Task
 class OkBuckGradlePlugin implements Plugin<Project> {
 
     void apply(Project project) {
-        project.extensions.create("okbuck", OkBuckExtension)
+        project.extensions.create("okbuck", OkBuckExtension, project)
 
         Task okBuckClean = project.task('okbuckClean')
         okBuckClean << {
@@ -57,7 +57,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
                 okBuckScriptsDir.deleteDir()
                 File dotBuckConfig = new File("${project.projectDir.absolutePath}/.buckconfig")
                 dotBuckConfig.delete()
-                project.subprojects { prj ->
+                project.okbuck.toBuck.each { prj ->
                     File buck = new File("${prj.projectDir.absolutePath}/BUCK")
                     buck.delete()
                 }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/OkBuckGradlePlugin.groovy
@@ -57,7 +57,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
                 okBuckScriptsDir.deleteDir()
                 File dotBuckConfig = new File("${project.projectDir.absolutePath}/.buckconfig")
                 dotBuckConfig.delete()
-                project.okbuck.toBuck.each { prj ->
+                project.okbuck.buckProjects.each { prj ->
                     File buck = new File("${prj.projectDir.absolutePath}/BUCK")
                     buck.delete()
                 }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/dependency/DependencyAnalyzer.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/dependency/DependencyAnalyzer.groovy
@@ -92,7 +92,7 @@ public final class DependencyAnalyzer {
     }
 
     private void combineFlavorVariant() {
-        for (Project project : mRootProject.okbuck.toBuck) {
+        for (Project project : mRootProject.okbuck.buckProjects) {
             switch (ProjectHelper.getSubProjectType(project)) {
                 case ProjectHelper.ProjectType.JavaLibProject:
                     mFinalDependencies.put(project, new HashMap<String, Set<Dependency>>())

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/dependency/DependencyAnalyzer.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/dependency/DependencyAnalyzer.groovy
@@ -92,7 +92,7 @@ public final class DependencyAnalyzer {
     }
 
     private void combineFlavorVariant() {
-        for (Project project : mRootProject.subprojects) {
+        for (Project project : mRootProject.okbuck.toBuck) {
             switch (ProjectHelper.getSubProjectType(project)) {
                 case ProjectHelper.ProjectType.JavaLibProject:
                     mFinalDependencies.put(project, new HashMap<String, Set<Dependency>>())

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/dependency/DependencyExtractor.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/dependency/DependencyExtractor.groovy
@@ -86,7 +86,7 @@ public final class DependencyExtractor {
     }
 
     private extractAptDependencies() {
-        for (Project project : mRootProject.subprojects) {
+        for (Project project : mRootProject.okbuck.toBuck) {
             if (ProjectHelper.getSubProjectType(project) == ProjectHelper.ProjectType.Unknown) {
                 continue
             }
@@ -111,7 +111,7 @@ public final class DependencyExtractor {
     }
 
     private extractAnnotationProcessors() {
-        for (Project project : mRootProject.subprojects) {
+        for (Project project : mRootProject.okbuck.toBuck) {
             if (ProjectHelper.getSubProjectType(project) == ProjectHelper.ProjectType.Unknown) {
                 continue
             }
@@ -140,7 +140,7 @@ public final class DependencyExtractor {
     }
 
     private extractCompileDependencies() {
-        for (Project project : mRootProject.subprojects) {
+        for (Project project : mRootProject.okbuck.toBuck) {
             ProjectHelper.ProjectType type = ProjectHelper.getSubProjectType(project)
             if (type == ProjectHelper.ProjectType.Unknown) {
                 continue

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/dependency/DependencyExtractor.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/dependency/DependencyExtractor.groovy
@@ -86,7 +86,7 @@ public final class DependencyExtractor {
     }
 
     private extractAptDependencies() {
-        for (Project project : mRootProject.okbuck.toBuck) {
+        for (Project project : mRootProject.okbuck.buckProjects) {
             if (ProjectHelper.getSubProjectType(project) == ProjectHelper.ProjectType.Unknown) {
                 continue
             }
@@ -111,7 +111,7 @@ public final class DependencyExtractor {
     }
 
     private extractAnnotationProcessors() {
-        for (Project project : mRootProject.okbuck.toBuck) {
+        for (Project project : mRootProject.okbuck.buckProjects) {
             if (ProjectHelper.getSubProjectType(project) == ProjectHelper.ProjectType.Unknown) {
                 continue
             }
@@ -140,7 +140,7 @@ public final class DependencyExtractor {
     }
 
     private extractCompileDependencies() {
-        for (Project project : mRootProject.okbuck.toBuck) {
+        for (Project project : mRootProject.okbuck.buckProjects) {
             ProjectHelper.ProjectType type = ProjectHelper.getSubProjectType(project)
             if (type == ProjectHelper.ProjectType.Unknown) {
                 continue

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/BuckFileGenerator.groovy
@@ -85,7 +85,7 @@ public final class BuckFileGenerator {
     public Map<Project, BUCKFile> generate() {
         Map<Project, BUCKFile> buckFileMap = new HashMap<>()
 
-        for (Project project : mRootProject.okbuck.toBuck) {
+        for (Project project : mRootProject.okbuck.buckProjects) {
             List<AbstractBuckRule> rules = new ArrayList<>()
             switch (ProjectHelper.getSubProjectType(project)) {
                 case ProjectHelper.ProjectType.AndroidAppProject:

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/BuckFileGenerator.groovy
@@ -85,7 +85,7 @@ public final class BuckFileGenerator {
     public Map<Project, BUCKFile> generate() {
         Map<Project, BUCKFile> buckFileMap = new HashMap<>()
 
-        for (Project project : mRootProject.subprojects) {
+        for (Project project : mRootProject.okbuck.toBuck) {
             List<AbstractBuckRule> rules = new ArrayList<>()
             switch (ProjectHelper.getSubProjectType(project)) {
                 case ProjectHelper.ProjectType.AndroidAppProject:

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/DotBuckConfigGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/DotBuckConfigGenerator.groovy
@@ -57,7 +57,7 @@ public final class DotBuckConfigGenerator {
      */
     public DotBuckConfigFile generate() {
         Map<String, String> alias = new HashMap<>()
-        for (Project project : mRootProject.subprojects) {
+        for (Project project : mRootProject.okbuck.toBuck) {
             if (ProjectHelper.getSubProjectType(
                     project) == ProjectHelper.ProjectType.AndroidAppProject) {
                 if (ProjectHelper.exportFlavor(project)) {

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/DotBuckConfigGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/DotBuckConfigGenerator.groovy
@@ -57,7 +57,7 @@ public final class DotBuckConfigGenerator {
      */
     public DotBuckConfigFile generate() {
         Map<String, String> alias = new HashMap<>()
-        for (Project project : mRootProject.okbuck.toBuck) {
+        for (Project project : mRootProject.okbuck.buckProjects) {
             if (ProjectHelper.getSubProjectType(
                     project) == ProjectHelper.ProjectType.AndroidAppProject) {
                 if (ProjectHelper.exportFlavor(project)) {

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/helper/ProjectHelper.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/helper/ProjectHelper.groovy
@@ -144,7 +144,7 @@ public final class ProjectHelper {
      * if the dependency is an module dependency, return the module dependency project, null otherwise.
      * */
     public static Project getModuleDependencyProject(Project rootProject, File dependency) {
-        for (Project project : rootProject.okbuck.toBuck) {
+        for (Project project : rootProject.okbuck.buckProjects) {
             if (dependency.absolutePath.startsWith(project.buildDir.absolutePath)) {
                 return project
             }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/helper/ProjectHelper.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/helper/ProjectHelper.groovy
@@ -144,7 +144,7 @@ public final class ProjectHelper {
      * if the dependency is an module dependency, return the module dependency project, null otherwise.
      * */
     public static Project getModuleDependencyProject(Project rootProject, File dependency) {
-        for (Project project : rootProject.subprojects) {
+        for (Project project : rootProject.okbuck.toBuck) {
             if (dependency.absolutePath.startsWith(project.buildDir.absolutePath)) {
                 return project
             }

--- a/plugin
+++ b/plugin
@@ -1,0 +1,1 @@
+buildSrc

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':dummylibrary', ':libraries:javalibrary', ':libraries:emptylibrary', ':libraries:common', ':anotherapp'
+include ':app', ':dummylibrary', ':libraries:javalibrary', ':libraries:emptylibrary', ':libraries:common', ':anotherapp', ':plugin'


### PR DESCRIPTION
- Allows optionally only listing a set of projects to convert to buck. There are cases when some projects should not be converted to buck.
- Also creates a symlink 'plugin' to buildSrc to allow `./gradlew plugin:publishToMavenLocal` for local testing of changes
- Only sets properties from `bintray.properties` file if it exists